### PR TITLE
Remove `DEVICE_CLASS_*` constants

### DIFF
--- a/custom_components/pod_point/binary_sensor.py
+++ b/custom_components/pod_point/binary_sensor.py
@@ -2,11 +2,13 @@
 import logging
 from typing import Dict, Any
 
-from homeassistant.components.binary_sensor import BinarySensorEntity
+from homeassistant.components.binary_sensor import (
+    BinarySensorEntity,
+    BinarySensorDeviceClass,
+)
 
 from .const import (
     ATTR_STATE,
-    BINARY_SENSOR_DEVICE_CLASS,
     DOMAIN,
 )
 from .entity import PodPointEntity
@@ -53,7 +55,7 @@ class PodPointBinarySensor(PodPointEntity, BinarySensorEntity):
     @property
     def device_class(self):
         """Return the class of this binary_sensor."""
-        return BINARY_SENSOR_DEVICE_CLASS
+        return BinarySensorDeviceClass.PLUG
 
     @property
     def is_on(self):

--- a/custom_components/pod_point/const.py
+++ b/custom_components/pod_point/const.py
@@ -19,9 +19,6 @@ ICON_EV_STATION = "mdi:ev-station"
 
 SWITCH_ICON = ICON_EV_STATION
 
-# Device classes
-BINARY_SENSOR_DEVICE_CLASS = "plug"
-
 # Platforms
 BINARY_SENSOR = "binary_sensor"
 SENSOR = "sensor"

--- a/custom_components/pod_point/sensor.py
+++ b/custom_components/pod_point/sensor.py
@@ -9,12 +9,11 @@ from homeassistant.components.sensor import (
     STATE_CLASS_TOTAL,
     STATE_CLASS_TOTAL_INCREASING,
     SensorEntity,
+    SensorDeviceClass,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ENERGY_KILO_WATT_HOUR,
-    DEVICE_CLASS_ENERGY,
-    DEVICE_CLASS_MONETARY,
 )
 from homeassistant.core import callback
 
@@ -204,7 +203,7 @@ class PodPointTotalEnergySensor(PodPointSensor):
 
     @property
     def device_class(self) -> str:
-        return DEVICE_CLASS_ENERGY
+        return SensorDeviceClass.ENERGY
 
     @property
     def state_class(self) -> str:
@@ -283,7 +282,7 @@ class PodPointTotalCostSensor(
 
     @property
     def device_class(self) -> str:
-        return DEVICE_CLASS_MONETARY
+        return SensorDeviceClass.MONETARY
 
     @property
     def unique_id(self):
@@ -343,7 +342,7 @@ class PodPointLastCompleteChargeCostSensor(
 
     @property
     def device_class(self) -> str:
-        return DEVICE_CLASS_MONETARY
+        return SensorDeviceClass.MONETARY
 
     @property
     def unique_id(self):

--- a/custom_components/pod_point/version.py
+++ b/custom_components/pod_point/version.py
@@ -1,2 +1,2 @@
 """Version of Pod Point integration"""
-__version__ = "0.4.3"
+__version__ = "0.4.4"


### PR DESCRIPTION
Fixes #14

* Removed depreciated `DEVICE_CLASS_*` constants from the codebase - @mattrayner  via @frenck
* Bumped version - @mattrayner 