### PR TITLE
Add missing translations - Fixes #17

### DIFF
--- a/custom_components/pod_point/config_flow.py
+++ b/custom_components/pod_point/config_flow.py
@@ -180,7 +180,7 @@ class PodPointOptionsFlowHandler(config_entries.OptionsFlow):
         }
 
         options_schema = vol.Schema(
-            {**currency_schema, **poll_schema, **platforms_schema, **debug_schema}
+            {**currency_schema, **platforms_schema, **debug_schema, **poll_schema}
         )
 
         return self.async_show_form(step_id="user", data_schema=options_schema)

--- a/custom_components/pod_point/const.py
+++ b/custom_components/pod_point/const.py
@@ -35,7 +35,7 @@ CONF_SCAN_INTERVAL = "scan_interval"
 DEFAULT_SCAN_INTERVAL = 300
 CONF_HTTP_DEBUG = "http_debug"
 DEFAULT_HTTP_DEBUG = False
-CONF_CURRENCY = "currancy"
+CONF_CURRENCY = "currency"
 DEFAULT_CURRENCY = "GBP"
 
 # Defaults

--- a/custom_components/pod_point/translations/en.json
+++ b/custom_components/pod_point/translations/en.json
@@ -36,7 +36,9 @@
                     "sensor": "Pod status, energy and cost sensors enabled.",
                     "switch": "Charging switch enabled.",
                     "scan_interval": "Poll interval (seconds)",
-                    "http_debug": "Enable verbose HTTP logging."
+                    "http_debug": "Enable verbose HTTP logging.",
+                    "update": "Enable firmware sensor",
+                    "currency": "Currency used for cost sensors"
                 }
             }
         }

--- a/custom_components/pod_point/version.py
+++ b/custom_components/pod_point/version.py
@@ -1,2 +1,2 @@
 """Version of Pod Point integration"""
-__version__ = "1.0.0"
+__version__ = "1.0.1"


### PR DESCRIPTION
As raised in #17 there are missing translations for both the new 'Update' platform, and the (previously mis-spelled) currency option.

- Adds update platform options translation
- Fixes curr*e*ncy translation mis-spell