### PR TITLE
Fix status priority for suspended-ev and suspended-evse

### DIFF
--- a/custom_components/pod_point/coordinator.py
+++ b/custom_components/pod_point/coordinator.py
@@ -340,8 +340,8 @@ expecting more charges. Page {page}, looking for : {last_charge_ids}"
         return (new_pods, new_pods_by_id)
 
     async def __async_refresh_firmware(
-        self, new_pods: List[Pod], new_pods_by_id: Dict[str, List[Pod]]
-    ) -> Dict[str, List[Pod]]:
+        self, new_pods: List[Pod], new_pods_by_id: Dict[str, Pod]
+    ) -> Dict[str, Pod]:
         _LOGGER.debug("=== FIRMWARE STATUS UPDATE ===")
 
         for pod in new_pods:
@@ -367,8 +367,8 @@ expecting more charges. Page {page}, looking for : {last_charge_ids}"
         return new_pods_by_id
 
     async def __async_update_pod_connection_status(
-        self, new_pods_by_id: Dict[str, List[Pod]]
-    ) -> Dict[str, List[Pod]]:
+        self, new_pods_by_id: Dict[str, Pod]
+    ) -> Dict[str, Pod]:
         _LOGGER.debug("=== POD CONNECTION STATUS UPDATE ===")
 
         # flat_pods = [item for row in new_pods_by_id.values() for item in row]
@@ -381,16 +381,8 @@ expecting more charges. Page {page}, looking for : {last_charge_ids}"
                 pod.last_message_at = connectivity_status.last_message_at
                 pod.charging_state = connectivity_status.charging_state
 
-                pod.statuses.append(
-                    Pod.Status(
-                        99,
-                        connectivity_status.charging_state,
-                        connectivity_status.charging_state,
-                        connectivity_status.charging_state,
-                        "A",
-                        1,
-                    )
-                )
+                if pod.charging_state is not None:
+                    pod.charging_state = pod.charging_state.lower().replace("_", "-")
 
                 new_pods_by_id[pod.unit_id] = pod
 

--- a/custom_components/pod_point/entity.py
+++ b/custom_components/pod_point/entity.py
@@ -85,6 +85,14 @@ class PodPointEntity(CoordinatorEntity):
         should_be_charging = is_charging_state and (
             is_override_charge_mode or is_manual_charge_mode
         )
+        should_be_suspended_ev = (
+                is_charging_state
+                and (pod.charging_state == ATTR_STATE_SUSPENDED_EV)
+        )
+        should_be_suspended_evse = (
+                is_charging_state
+                and (pod.charging_state == ATTR_STATE_SUSPENDED_EVSE)
+        )
         should_be_pending = (
             self.coordinator.last_message_at is not None
             and self.pod.last_message_at is not None
@@ -104,6 +112,14 @@ class PodPointEntity(CoordinatorEntity):
         # Pod should be charging if pod is charging and state is overriden, or manual charge mode
         if should_be_charging:
             state = ATTR_STATE_CHARGING
+
+        # Pod should be suspended evse if pod is charging and connectivity status is suspended evse
+        if should_be_suspended_evse:
+            state = ATTR_STATE_SUSPENDED_EVSE
+
+        # Pod should be suspended ev if pod is charging and connectivity status is suspended ev
+        if should_be_suspended_ev:
+            state = ATTR_STATE_SUSPENDED_EV
 
         # Should this pod be pending?
         if should_be_pending:

--- a/custom_components/pod_point/entity.py
+++ b/custom_components/pod_point/entity.py
@@ -25,6 +25,7 @@ from .const import (
     DOMAIN,
     NAME,
     ATTR_STATE_SUSPENDED_EV,
+    ATTR_STATE_SUSPENDED_EVSE,
     ATTR_STATE_IDLE,
     ATTR_STATE_PENDING,
 )
@@ -291,6 +292,7 @@ class PodPointEntity(CoordinatorEntity):
             CHARGING_FLAG,
             ATTR_STATE_CONNECTED_WAITING,
             ATTR_STATE_SUSPENDED_EV,
+            ATTR_STATE_SUSPENDED_EVSE,
         )
 
     @staticmethod

--- a/custom_components/pod_point/manifest.json
+++ b/custom_components/pod_point/manifest.json
@@ -570,5 +570,5 @@
     "aiodiscover",
     "scapy"
   ],
-  "version": "2.0.0"
+  "version": "2.0.2"
 }

--- a/custom_components/pod_point/version.py
+++ b/custom_components/pod_point/version.py
@@ -1,3 +1,3 @@
 """Version of the Pod Point integration"""
 
-__version__ = "2.0.0"
+__version__ = "2.0.2"

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -1,0 +1,111 @@
+"""Test pod_point binary sensors."""
+
+from typing import List, Union
+from unittest.mock import Mock, call, patch
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+)
+from homeassistant.helpers.entity import EntityCategory
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.pod_point import async_setup_entry
+from custom_components.pod_point.const import (
+    ATTR_CONNECTION_STATE_ONLINE,
+    DOMAIN, ATTR_STATE,
+)
+from custom_components.pod_point.binary_sensor import (
+    PodPointCableConnectionSensor,
+    PodPointCloudConnectionSensor,
+    async_setup_entry,
+)
+from podpointclient.connectivity_status import ConnectivityStatus, Evse
+
+from .const import MOCK_CONFIG
+from .fixtures import CONNECTIVITY_STATUS_COMPLETE_FIXTURE
+from .test_coordinator import subject_with_data as coordinator_with_data
+
+
+async def setup_sensors(hass) -> List[BinarySensorEntity]:
+    """Setup sensors within the test environment"""
+    coordinator = await coordinator_with_data(hass)
+
+    # Create a mock entry so we don't have to go through config flow
+    config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG, entry_id="test")
+
+    hass.data[DOMAIN] = {}
+    hass.data[DOMAIN][config_entry.entry_id] = coordinator
+
+    mock = Mock()
+
+    await async_setup_entry(hass, config_entry, mock)
+
+    print(mock.call_args_list)
+    sensors: List[Union(PodPointCableConnectionSensor, PodPointCloudConnectionSensor)] = (
+        mock.call_args_list[0][0][0]
+    )
+
+    return (config_entry, sensors)
+
+
+@pytest.mark.asyncio
+async def test_sensor_creation(hass, bypass_get_data):
+    """Test that the expected number of sensors is created"""
+
+    (_, sensors) = await setup_sensors(hass)
+
+    assert 2 == len(sensors)
+
+
+@pytest.mark.asyncio
+async def test_cloud_connection_sensor(hass, bypass_get_data):
+    """Tests for pod status sensor."""
+    (_, sensors) = await setup_sensors(hass)
+
+    [_, status] = sensors
+
+    assert BinarySensorDeviceClass.CONNECTIVITY == status.device_class
+    assert EntityCategory.DIAGNOSTIC == status.entity_category
+    assert "pod_point_12234_PSL-123456_cloud_connection" == status.unique_id
+    assert "Cloud Connection" == status.name
+
+    status.pod.connectivity_status = ConnectivityStatus(CONNECTIVITY_STATUS_COMPLETE_FIXTURE)
+    assert status.is_on is True
+    assert "mdi:cloud-check-variant" == status.icon
+
+    status.pod.connectivity_status.evses[0].connectivity_state.connectivity_status = "FOO"
+    assert status.is_on is False
+    assert "mdi:cloud-off" == status.icon
+
+
+@pytest.mark.asyncio
+async def test_cable_connection_sensor(hass, bypass_get_data):
+    """Tests for pod status sensor."""
+    (_, sensors) = await setup_sensors(hass)
+
+    [status, _] = sensors
+
+    assert BinarySensorDeviceClass.PLUG == status.device_class
+    assert "pod_point_12234_PSL-123456_cable_status" == status.unique_id
+    assert "Cable Status" == status.name
+
+    status.extra_attrs[ATTR_STATE] = "charging"
+    assert status.is_on is True
+
+    status.extra_attrs[ATTR_STATE] = "available"
+    assert status.is_on is False
+
+    status.extra_attrs[ATTR_STATE] = "connected-waiting-for-schedule"
+    assert status.is_on is True
+
+    status.extra_attrs[ATTR_STATE] = "suspended-evse"
+    assert status.is_on is True
+
+    status.extra_attrs[ATTR_STATE] = "suspended-ev"
+    assert status.is_on is True
+
+    status.extra_attrs[ATTR_STATE] = "foo"
+    assert status.is_on is False
+


### PR DESCRIPTION
This PR changes how we handle 'new' statuses from the `connectivity_status` endpoint.

Prior to this PR all statuses from the endpoint were given an overriding priority (99). This meant that regardless of the other device statuses (charging, available, out-of-service) these would be used.

An example of when this is incorrect is:

> Pod is not connected to an EV (status `avalable`), and there is a schedule preventing charging (status `waiting-for-schedule`), and the `connectivity_status` returns `SUSPENDED_EVSE` (state `suspended-evse`).

In the above scenario this results in `suspended-evse` rather than `waiting-for-schedule` being the status, and then the Home Assistant translations kick in to make this: 'Charging Paused'.

This also caused `pod.connected` == `True` and the cable status to incorrectly show as plugged in.

Fixes #55