### PR TITLE
DHCP ServiceInfo deprecation in 2025.2

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
 	"name": "Pod Point integration development",
-	"image": "mcr.microsoft.com/devcontainers/python:3.12-bullseye",
+	"image": "mcr.microsoft.com/devcontainers/python:3.13-bullseye",
 	"postCreateCommand": "scripts/setup",
 	"forwardPorts": [
 		8123

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -25,7 +25,7 @@ jobs:
         - uses: "actions/checkout@v2"
         - uses: "actions/setup-python@v1"
           with:
-            python-version: "3.12"
+            python-version: "3.13"
         - run: python3 -m pip install black
         - run: black .
 
@@ -38,7 +38,7 @@ jobs:
       - name: Setup Python
         uses: "actions/setup-python@v1"
         with:
-          python-version: "3.12"
+          python-version: "3.13"
       - name: Install requirements
         run: python3 -m pip install -r requirements_test.txt -r requirements.txt
       - name: Run tests

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -25,7 +25,7 @@ jobs:
         - uses: "actions/checkout@v2"
         - uses: "actions/setup-python@v1"
           with:
-            python-version: "3.12"
+            python-version: "3.13"
         - run: python3 -m pip install black
         - run: black .
 
@@ -38,7 +38,7 @@ jobs:
       - name: Setup Python
         uses: "actions/setup-python@v1"
         with:
-          python-version: "3.12"
+          python-version: "3.13"
       - name: Install requirements
         run: python3 -m pip install -r requirements_test.txt -r requirements.txt
       - name: Run tests

--- a/custom_components/pod_point/config_flow.py
+++ b/custom_components/pod_point/config_flow.py
@@ -4,7 +4,7 @@ import logging
 from typing import Dict
 
 from homeassistant import config_entries
-from homeassistant.components import dhcp
+from homeassistant.helpers.service_info  import dhcp
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.aiohttp_client import async_create_clientsession

--- a/custom_components/pod_point/config_flow.py
+++ b/custom_components/pod_point/config_flow.py
@@ -4,7 +4,7 @@ import logging
 from typing import Dict
 
 from homeassistant import config_entries
-from homeassistant.helpers.service_info  import dhcp
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
@@ -91,7 +91,7 @@ class PodPointFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     def async_get_options_flow(config_entry) -> FlowResult:
         return PodPointOptionsFlowHandler(config_entry)
 
-    async def async_step_dhcp(self, discovery_info: dhcp.DhcpServiceInfo) -> FlowResult:
+    async def async_step_dhcp(self, discovery_info: DhcpServiceInfo) -> FlowResult:
         formatted_mac = format_mac(discovery_info.macaddress)
         _LOGGER.info("Found PodPoint device with mac %s", formatted_mac)
 

--- a/hacs.json
+++ b/hacs.json
@@ -2,5 +2,5 @@
     "name": "Pod Point",
     "country": "GB",
     "hacs": "1.6.0",
-    "homeassistant": "2024.11.0"
+    "homeassistant": "2025.2.0"
 }

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,3 +1,3 @@
-pytest-homeassistant-custom-component>=0.13.210
+pytest-homeassistant-custom-component>=0.13.175
 pytest-asyncio
 aiodhcpwatcher

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,3 +1,3 @@
-pytest-homeassistant-custom-component>=0.13.175
+pytest-homeassistant-custom-component>=0.13.210
 pytest-asyncio
 aiodhcpwatcher

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,3 +1,3 @@
-pytest-homeassistant-custom-component>=0.12.57
+pytest-homeassistant-custom-component>=0.13.210
 pytest-asyncio
 aiodhcpwatcher

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -4,7 +4,7 @@ from types import MappingProxyType
 from unittest.mock import patch
 
 from homeassistant import config_entries, data_entry_flow
-from homeassistant.components import dhcp
+from homeassistant.helpers.service_info  import dhcp
 from homeassistant.core import HomeAssistant
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 from homeassistant import config_entries
 from homeassistant.data_entry_flow import FlowResultType
-from homeassistant.helpers.service_info  import dhcp
+from homeassistant.helpers.service_info import dhcp
 from homeassistant.core import HomeAssistant
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -87,12 +87,14 @@ async def test_reauth_config_flow(hass, bypass_get_data):
     entry.add_to_hass(hass)
 
     # Initialize a config flow
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_REAUTH}
-    )
+    entry.async_start_reauth(hass)
+    await hass.async_block_till_done()
+    flows = hass.config_entries.flow.async_progress()
+    assert len(flows) == 1
+    result = flows[0]
 
     # Check that the config flow shows the reauth form as the first step
-    assert result["type"] == FlowResultType.FORM
+    # assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "reauth_confirm"
 
     # If a user were to confirm the re-auth start, this function call

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -87,9 +87,7 @@ async def test_reauth_config_flow(hass, bypass_get_data):
     entry.add_to_hass(hass)
 
     # Initialize a config flow
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_REAUTH}
-    )
+    result = await entry.async_start_reauth(hass)
 
     # Check that the config flow shows the reauth form as the first step
     assert result["type"] == FlowResultType.FORM

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -3,7 +3,8 @@
 from types import MappingProxyType
 from unittest.mock import patch
 
-from homeassistant import config_entries, data_entry_flow
+from homeassistant import config_entries
+from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers.service_info  import dhcp
 from homeassistant.core import HomeAssistant
 import pytest
@@ -59,7 +60,7 @@ async def test_successful_config_flow(hass, bypass_get_data):
     )
 
     # Check that the config flow shows the user form as the first step
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "user"
 
     # If a user were to enter `test_username` for username and `test_password`
@@ -70,7 +71,7 @@ async def test_successful_config_flow(hass, bypass_get_data):
 
     # Check that the config flow is complete and a new entry is created with
     # the input data
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["title"] == "test@example.com"
     assert result["data"] == MOCK_CONFIG
     assert result["result"]
@@ -91,7 +92,7 @@ async def test_reauth_config_flow(hass, bypass_get_data):
     )
 
     # Check that the config flow shows the reauth form as the first step
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "reauth_confirm"
 
     # If a user were to confirm the re-auth start, this function call
@@ -100,7 +101,7 @@ async def test_reauth_config_flow(hass, bypass_get_data):
     )
 
     # It should load the user form
-    assert result_2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result_2["type"] == FlowResultType.FORM
     assert result_2["step_id"] == "user"
 
     updated_config = MOCK_CONFIG
@@ -113,7 +114,7 @@ async def test_reauth_config_flow(hass, bypass_get_data):
 
     # Check that the config flow is complete and a new entry is created with
     # the input data
-    assert result_3["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result_3["type"] == FlowResultType.CREATE_ENTRY
     assert result_3["title"] == "test@example.com"
     assert result_3["data"] == MOCK_CONFIG
     assert result_3["result"]
@@ -130,14 +131,14 @@ async def test_failed_config_flow(hass, error_on_get_data):
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "user"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input=MOCK_CONFIG
     )
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["errors"] == {"base": "auth"}
 
 
@@ -154,7 +155,7 @@ async def test_options_flow(hass, bypass_get_data):
     result = await hass.config_entries.options.async_init(entry.entry_id)
 
     # Verify that the first options step is a user form
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["step_id"] == "user"
 
     # Enter some fake data into the form
@@ -164,7 +165,7 @@ async def test_options_flow(hass, bypass_get_data):
     )
 
     # Verify that the flow finishes
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["title"] == "test@example.com"
 
     # Verify that the options were updated
@@ -190,7 +191,7 @@ async def test_dhcp_flow(hass: HomeAssistant, bypass_get_data) -> None:
         data=DHCP_SERVICE_INFO,
         context={"source": config_entries.SOURCE_DHCP},
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "user"
 
     result2 = await hass.config_entries.flow.async_configure(
@@ -209,7 +210,7 @@ async def test_dhcp_login_error(hass: HomeAssistant, bypass_get_data) -> None:
         data=DHCP_SERVICE_INFO,
         context={"source": config_entries.SOURCE_DHCP},
     )
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "user"
     with patch(
         "podpointclient.client.PodPointClient.async_credentials_verified",

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -87,7 +87,7 @@ async def test_reauth_config_flow(hass, bypass_get_data):
     entry.add_to_hass(hass)
 
     # Initialize a config flow
-    result = entry.async_start_reauth(hass)
+    result = await entry.async_start_reauth(hass)
 
     # Check that the config flow shows the reauth form as the first step
     assert result["type"] == FlowResultType.FORM

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -87,7 +87,7 @@ async def test_reauth_config_flow(hass, bypass_get_data):
     entry.add_to_hass(hass)
 
     # Initialize a config flow
-    result = await entry.async_start_reauth(hass)
+    result = entry.async_start_reauth(hass)
 
     # Check that the config flow shows the reauth form as the first step
     assert result["type"] == FlowResultType.FORM

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -155,7 +155,7 @@ async def test_options_flow(hass, bypass_get_data):
     result = await hass.config_entries.options.async_init(entry.entry_id)
 
     # Verify that the first options step is a user form
-    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "user"
 
     # Enter some fake data into the form

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -87,7 +87,9 @@ async def test_reauth_config_flow(hass, bypass_get_data):
     entry.add_to_hass(hass)
 
     # Initialize a config flow
-    result = await entry.async_start_reauth(hass)
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_REAUTH}
+    )
 
     # Check that the config flow shows the reauth form as the first step
     assert result["type"] == FlowResultType.FORM

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -10,11 +10,11 @@ from unittest.mock import Mock, call, patch
 from homeassistant.components import switch
 from homeassistant.components.sensor import (
     SensorStateClass,
+    SensorDeviceClass,
 )
 from homeassistant.components.switch import SERVICE_TURN_OFF, SERVICE_TURN_ON
 from homeassistant.const import (
     ATTR_ENTITY_ID,
-    DEVICE_CLASS_ENERGY,
     ENERGY_KILO_WATT_HOUR,
 )
 import homeassistant.helpers.aiohttp_client as client

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -9,8 +9,7 @@ from unittest.mock import Mock, call, patch
 # import aiohttp
 from homeassistant.components import switch
 from homeassistant.components.sensor import (
-    STATE_CLASS_TOTAL,
-    STATE_CLASS_TOTAL_INCREASING,
+    SensorStateClass,
 )
 from homeassistant.components.switch import SERVICE_TURN_OFF, SERVICE_TURN_ON
 from homeassistant.const import (

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -15,7 +15,7 @@ from homeassistant.components.sensor import (
 from homeassistant.components.switch import SERVICE_TURN_OFF, SERVICE_TURN_ON
 from homeassistant.const import (
     ATTR_ENTITY_ID,
-    ENERGY_KILO_WATT_HOUR,
+    UnitOfEnergy,
 )
 import homeassistant.helpers.aiohttp_client as client
 from podpointclient.charge_mode import ChargeMode

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -8,8 +8,7 @@ from unittest.mock import Mock, call, patch
 import aiohttp
 from homeassistant.components import switch
 from homeassistant.components.sensor import (
-    STATE_CLASS_TOTAL,
-    STATE_CLASS_TOTAL_INCREASING,
+    SensorStateClass,
     SensorDeviceClass,
 )
 from homeassistant.components.switch import SERVICE_TURN_OFF, SERVICE_TURN_ON
@@ -155,7 +154,7 @@ async def test_total_energy_pod_sensor(hass, bypass_get_data):
     assert "Total Energy" == total_energy.name
 
     assert DEVICE_CLASS_ENERGY == total_energy.device_class
-    assert STATE_CLASS_TOTAL_INCREASING == total_energy.state_class
+    assert SensorStateClass.TOTAL_INCREASING == total_energy.state_class
     assert 0.0 == total_energy.native_value
     assert ENERGY_KILO_WATT_HOUR == total_energy.native_unit_of_measurement
     assert "mdi:lightning-bolt-outline" == total_energy.icon
@@ -183,7 +182,7 @@ async def test_current_energy_pod_sensor(hass, bypass_get_data):
     assert "Current Energy" == current_energy.name
 
     assert DEVICE_CLASS_ENERGY == current_energy.device_class
-    assert STATE_CLASS_TOTAL == current_energy.state_class
+    assert SensorStateClass.TOTAL == current_energy.state_class
     assert 0.0 == current_energy.native_value
     assert "mdi:car-electric" == current_energy.icon
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -14,7 +14,6 @@ from homeassistant.components.sensor import (
 from homeassistant.components.switch import SERVICE_TURN_OFF, SERVICE_TURN_ON
 from homeassistant.const import (
     ATTR_ENTITY_ID,
-    DEVICE_CLASS_ENERGY,
     ENERGY_KILO_WATT_HOUR,
 )
 import homeassistant.helpers.aiohttp_client as client
@@ -153,7 +152,7 @@ async def test_total_energy_pod_sensor(hass, bypass_get_data):
 
     assert "Total Energy" == total_energy.name
 
-    assert DEVICE_CLASS_ENERGY == total_energy.device_class
+    assert SensorDeviceClass.ENERGY == total_energy.device_class
     assert SensorStateClass.TOTAL_INCREASING == total_energy.state_class
     assert 0.0 == total_energy.native_value
     assert ENERGY_KILO_WATT_HOUR == total_energy.native_unit_of_measurement
@@ -181,7 +180,7 @@ async def test_current_energy_pod_sensor(hass, bypass_get_data):
 
     assert "Current Energy" == current_energy.name
 
-    assert DEVICE_CLASS_ENERGY == current_energy.device_class
+    assert SensorDeviceClass.ENERGY == current_energy.device_class
     assert SensorStateClass.TOTAL == current_energy.state_class
     assert 0.0 == current_energy.native_value
     assert "mdi:car-electric" == current_energy.icon

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -14,7 +14,7 @@ from homeassistant.components.sensor import (
 from homeassistant.components.switch import SERVICE_TURN_OFF, SERVICE_TURN_ON
 from homeassistant.const import (
     ATTR_ENTITY_ID,
-    ENERGY_KILO_WATT_HOUR,
+    UnitOfEnergy,
 )
 import homeassistant.helpers.aiohttp_client as client
 from podpointclient.charge_override import ChargeOverride
@@ -155,7 +155,7 @@ async def test_total_energy_pod_sensor(hass, bypass_get_data):
     assert SensorDeviceClass.ENERGY == total_energy.device_class
     assert SensorStateClass.TOTAL_INCREASING == total_energy.state_class
     assert 0.0 == total_energy.native_value
-    assert ENERGY_KILO_WATT_HOUR == total_energy.native_unit_of_measurement
+    assert UnitOfEnergy.KILO_WATT_HOUR == total_energy.native_unit_of_measurement
     assert "mdi:lightning-bolt-outline" == total_energy.icon
     assert False == total_energy.is_on
 

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -8,8 +8,7 @@ from unittest.mock import Mock, call, patch
 import aiohttp
 from homeassistant.components import switch
 from homeassistant.components.sensor import (
-    STATE_CLASS_TOTAL,
-    STATE_CLASS_TOTAL_INCREASING,
+    SensorStateClass,
     SensorDeviceClass,
 )
 from homeassistant.components.switch import SERVICE_TURN_OFF, SERVICE_TURN_ON

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -14,7 +14,7 @@ from homeassistant.components.sensor import (
 from homeassistant.components.switch import SERVICE_TURN_OFF, SERVICE_TURN_ON
 from homeassistant.const import (
     ATTR_ENTITY_ID,
-    ENERGY_KILO_WATT_HOUR,
+    UnitOfEnergy,
 )
 import homeassistant.helpers.aiohttp_client as client
 from podpointclient.pod import Pod

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -14,7 +14,6 @@ from homeassistant.components.sensor import (
 from homeassistant.components.switch import SERVICE_TURN_OFF, SERVICE_TURN_ON
 from homeassistant.const import (
     ATTR_ENTITY_ID,
-    DEVICE_CLASS_ENERGY,
     ENERGY_KILO_WATT_HOUR,
 )
 import homeassistant.helpers.aiohttp_client as client


### PR DESCRIPTION
Resolves https://github.com/mattrayner/pod-point-home-assistant-component/issues/73
An internal class has been moved in HA so it just changing the package.   Looks to be effective from 2025.2 so have bumped minimum version in HACS

