### PR TITLE
Return the correct cable connection status during pending/offline states

### DIFF
--- a/custom_components/pod_point/binary_sensor.py
+++ b/custom_components/pod_point/binary_sensor.py
@@ -1,7 +1,6 @@
 """Binary sensor platform for pod_point."""
 
 import logging
-from typing import Any, Dict
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -9,7 +8,7 @@ from homeassistant.components.binary_sensor import (
 )
 from homeassistant.helpers.entity import EntityCategory
 
-from .const import ATTR_CONNECTION_STATE_ONLINE, ATTR_STATE, ATTRIBUTION, DOMAIN
+from .const import DOMAIN
 from .coordinator import PodPointDataUpdateCoordinator
 from .entity import PodPointEntity
 
@@ -48,7 +47,7 @@ class PodPointCableConnectionSensor(PodPointEntity, BinarySensorEntity):
         return f"{super().unique_id}_cable_status"
 
     @property
-    def is_on(self):
+    def is_on(self) -> bool | None:
         """Return true if the binary_sensor is on."""
         return self.connected
 
@@ -66,18 +65,9 @@ class PodPointCloudConnectionSensor(PodPointEntity, BinarySensorEntity):
         return f"{super().unique_id}_cloud_connection"
 
     @property
-    def is_on(self):
+    def is_on(self) -> bool:
         """Return true if the binary_sensor is on."""
-        if self.pod is None:
-            return False
-
-        if self.pod.connectivity_status is None:
-            return False
-
-        return (
-            self.pod.connectivity_status.connectivity_status
-            == ATTR_CONNECTION_STATE_ONLINE
-        )
+        return self.online
 
     @property
     def icon(self):

--- a/custom_components/pod_point/entity.py
+++ b/custom_components/pod_point/entity.py
@@ -299,14 +299,23 @@ class PodPointEntity(CoordinatorEntity):
         return self.__pod_image(self.model)
 
     @property
-    def connected(self) -> bool:
-        """Returns true if pod is connected to a vehicle"""
-        status = self.extra_state_attributes.get(ATTR_STATE, "")
-        return status in (
-            CHARGING_FLAG,
-            ATTR_STATE_CONNECTED_WAITING,
-            ATTR_STATE_SUSPENDED_EV,
-            ATTR_STATE_SUSPENDED_EVSE,
+    def connected(self) -> bool | None:
+        """Return True if pod is connected to a vehicle, None (unknown) if it is offline."""
+        if not self.online:
+            return None
+        return any(
+            status.key_name in {ATTR_STATE_CHARGING, ATTR_STATE_SUSPENDED_EV}
+            for status in self.pod.statuses
+        )
+
+    @property
+    def online(self) -> bool:
+        """Return True if pod is online."""
+        if self.pod is None or self.pod.connectivity_status is None:
+            return False
+        return (
+            self.pod.connectivity_status.connectivity_status
+            == ATTR_CONNECTION_STATE_ONLINE
         )
 
     @staticmethod

--- a/custom_components/pod_point/entity.py
+++ b/custom_components/pod_point/entity.py
@@ -14,6 +14,7 @@ from podpointclient.schedule import Schedule
 
 from .const import (
     APP_IMAGE_URL_BASE,
+    ATTR_CONNECTION_STATE_ONLINE,
     ATTR_STATE,
     ATTR_STATE_AVAILABLE,
     ATTR_STATE_CHARGING,
@@ -25,7 +26,6 @@ from .const import (
     ATTR_STATE_SUSPENDED_EVSE,
     ATTR_STATE_WAITING,
     ATTRIBUTION,
-    CHARGING_FLAG,
     DOMAIN,
     NAME,
 )


### PR DESCRIPTION
## Summary
This PR amends the handling for the cable connection binary sensor to ensure it is handled consistently during pending/offline states, currently it switches to unplugged whilst the pod status is pending/offline.

## What's changed
- The `connected` property checks the reported pod statuses rather than entity state to confirm if the cable is connected, this ensures it remains `on` (connected) after a command is issued from Home Assistant to the Pod Point cloud
- The cable connection binary sensor now returns `unknown` rather than `off` (unplugged) if the device is offline