### PR TITLE
Fix null schedule status crashing all platforms, and 500 on the options flow

### DIFF
--- a/custom_components/pod_point/config_flow.py
+++ b/custom_components/pod_point/config_flow.py
@@ -136,7 +136,10 @@ class PodPointOptionsFlowHandler(config_entries.OptionsFlow):
 
     def __init__(self, config_entry):
         """Initialize HACS options flow."""
-        self.config_entry = config_entry
+        # `config_entry` is a read-only property on OptionsFlow as of Home Assistant
+        # 2024.11, and is populated by the flow manager. Assigning it raises
+        # AttributeError, which the frontend shows as
+        # "Config flow could not be loaded: 500 Internal Server Error".
         self.options = dict(config_entry.options)
 
     async def async_step_init(

--- a/custom_components/pod_point/coordinator.py
+++ b/custom_components/pod_point/coordinator.py
@@ -157,7 +157,7 @@ Updated Charges: %s\nCombined Charges: %s",
 
             self.pods = list(new_pods_by_id.values())
 
-            self.__default_missing_schedule_statuses(self.pods)
+            self.__default_missing_schedule_statuses(self.__pods_with_schedules())
 
             if self.online is False:
                 _LOGGER.info("Connection to Pod Point re-established.")
@@ -189,6 +189,23 @@ If this issue persists, please contact the developer."
             )
             _LOGGER.exception(exception)
             raise UpdateFailed() from exception
+
+    def __pods_with_schedules(self) -> List[Pod]:
+        """Every Pod reachable from coordinator state that carries schedules.
+
+        `self.pods` is not the whole story: the user has its own nested Pod at
+        `user.unit.pod`, with its own charge_schedules. sensor.py reaches it via
+        `attrs.update(user.dict)`, so leaving it out gives a second, less obvious
+        route to the same crash - one that fires on every coordinator refresh
+        rather than at setup.
+        """
+        pods = list(self.pods or [])
+
+        user_pod = getattr(getattr(self.user, "unit", None), "pod", None)
+        if user_pod is not None:
+            pods.append(user_pod)
+
+        return pods
 
     def __default_missing_schedule_statuses(self, pods: List[Pod]) -> None:
         """Give schedules that arrived without a status the library default.

--- a/custom_components/pod_point/coordinator.py
+++ b/custom_components/pod_point/coordinator.py
@@ -14,6 +14,7 @@ from podpointclient.charge import Charge
 from podpointclient.client import PodPointClient
 from podpointclient.errors import ApiConnectionError, AuthError, SessionError
 from podpointclient.pod import Firmware, Pod
+from podpointclient.schedule import ScheduleStatus
 from podpointclient.user import User
 import pytz
 
@@ -156,6 +157,8 @@ Updated Charges: %s\nCombined Charges: %s",
 
             self.pods = list(new_pods_by_id.values())
 
+            self.__default_missing_schedule_statuses(self.pods)
+
             if self.online is False:
                 _LOGGER.info("Connection to Pod Point re-established.")
             self.online = True
@@ -186,6 +189,36 @@ If this issue persists, please contact the developer."
             )
             _LOGGER.exception(exception)
             raise UpdateFailed() from exception
+
+    def __default_missing_schedule_statuses(self, pods: List[Pod]) -> None:
+        """Give schedules that arrived without a status the library default.
+
+        Pod Point can return charge schedules with no `status`, in which case
+        podpointclient leaves `Schedule.status` as None. `Schedule.dict` and
+        `Schedule.is_active` both dereference it unconditionally, so a single such
+        schedule raises AttributeError and takes down every platform at setup.
+
+        Defaulting here means the fix applies wherever the data is read: `entity.py`
+        touches it both in `__update_attrs` (via `pod.dict`) and in the
+        `charging_allowed` property. `charging_allowed` already handles `is_active`
+        being None, but not `status` itself being None.
+
+        `ScheduleStatus()` defaults `is_active` to False, which is also the safer
+        reading - an unknown schedule state should not be treated as an active
+        restriction on charging.
+        """
+        defaulted = 0
+        for pod in pods:
+            for schedule in getattr(pod, "charge_schedules", None) or []:
+                if getattr(schedule, "status", None) is None:
+                    schedule.status = ScheduleStatus()
+                    defaulted += 1
+
+        if defaulted:
+            _LOGGER.debug(
+                "Defaulted %s charge schedule(s) that arrived without a status",
+                defaulted,
+            )
 
     def __group_pods_by_unit_id(self, pods: List[Pod] = None) -> Dict[int, Pod]:
         """Given a list of pods, will return a dictionary { pod.unit_id: pod, *** }.

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -28,7 +28,10 @@ from .const import MOCK_CONFIG
 DHCP_SERVICE_INFO = dhcp.DhcpServiceInfo(
     hostname="podpoint-245EBE000000",
     ip="192.168.1.200",
-    macaddress="245EBE000000",
+    # Home Assistant requires this unformatted and lowercase. An uppercase value now
+    # raises "ValueError: macaddress is not correctly formatted" at import time,
+    # which fails collection of this entire module - and with it the whole suite.
+    macaddress="245ebe000000",
 )
 
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -194,7 +194,7 @@ async def test_coordinator_refresh_defaults_missing_schedule_status(
     pod.charge_schedules[0].status = None
 
     coordinator._PodPointDataUpdateCoordinator__default_missing_schedule_statuses(
-        coordinator.data
+        coordinator._PodPointDataUpdateCoordinator__pods_with_schedules()
     )
 
     schedule = pod.charge_schedules[0]
@@ -204,3 +204,31 @@ async def test_coordinator_refresh_defaults_missing_schedule_status(
     # The two call sites that used to raise
     assert schedule.dict["status"]["is_active"] is False
     assert pod.dict is not None
+
+
+# The user carries its own nested Pod at user.unit.pod, with its own schedules, which
+# sensor.py reads via `attrs.update(user.dict)`. That is a second route to the same
+# crash, and it fires on every coordinator refresh rather than at setup:
+#   File "custom_components/pod_point/sensor.py", line 663, in __update_attrs
+#     attrs.update(user.dict)
+@pytest.mark.asyncio
+async def test_coordinator_refresh_defaults_user_pod_schedule_status(
+    hass, bypass_get_data
+):
+    """A null status on the user's own nested pod is defaulted too."""
+    coordinator: PodPointDataUpdateCoordinator = await subject(hass)
+
+    await coordinator.async_refresh()
+
+    user_pod = getattr(getattr(coordinator.user, "unit", None), "pod", None)
+    if user_pod is None or not user_pod.charge_schedules:
+        pytest.skip("user fixture has no nested pod schedules")
+
+    user_pod.charge_schedules[0].status = None
+
+    coordinator._PodPointDataUpdateCoordinator__default_missing_schedule_statuses(
+        coordinator._PodPointDataUpdateCoordinator__pods_with_schedules()
+    )
+
+    assert user_pod.charge_schedules[0].status is not None
+    assert coordinator.user.dict is not None

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -172,3 +172,35 @@ async def test_coordinator_refresh_unexpected_exception(hass, error_on_get_data)
 
 
 # TODO: Add a test for repair flow creation and cleanup
+
+
+# Pod Point can return a charge schedule with no status, in which case
+# podpointclient leaves Schedule.status as None. Schedule.dict and
+# Schedule.is_active both dereference it unconditionally, so one such schedule
+# raised AttributeError and took down every platform at setup.
+@pytest.mark.asyncio
+async def test_coordinator_refresh_defaults_missing_schedule_status(
+    hass, bypass_get_data
+):
+    """A schedule with no status is given the library default rather than crashing."""
+    coordinator: PodPointDataUpdateCoordinator = await subject(hass)
+
+    await coordinator.async_refresh()
+
+    pod: Pod = coordinator.data[0]
+    assert len(pod.charge_schedules) > 0
+
+    # Simulate the API response that caused the crash
+    pod.charge_schedules[0].status = None
+
+    coordinator._PodPointDataUpdateCoordinator__default_missing_schedule_statuses(
+        coordinator.data
+    )
+
+    schedule = pod.charge_schedules[0]
+    assert schedule.status is not None
+    assert schedule.is_active is False
+
+    # The two call sites that used to raise
+    assert schedule.dict["status"]["is_active"] is False
+    assert pod.dict is not None


### PR DESCRIPTION
Two independent bugs that between them made the integration unusable for me on Home Assistant 2026.8.0. Both are small and unrelated, so they're separate commits — happy to split into two PRs if you'd prefer.

## 1. Charge schedules with no status crash every platform

Pod Point started returning charge schedules with no `status`, so `podpointclient` leaves `Schedule.status` as `None`. Both `Schedule.dict` and `Schedule.is_active` dereference it unconditionally:

```
AttributeError: 'NoneType' object has no attribute 'is_active'
  File "/config/custom_components/pod_point/entity.py", line 67, in __update_attrs
    attrs.update(pod.dict)
  File ".../podpointclient/pod.py", line 306, in dict
    dictionary['charge_schedules'].append(charge_schedule.dict)
  File ".../podpointclient/schedule.py", line 34, in dict
    "is_active": self.status.is_active
```

One such schedule is enough to fail setup for **all four platforms**, so every entity for the pod goes unavailable:

```
ERROR ... Error while setting up pod_point platform for sensor:        'NoneType' object has no attribute 'is_active'
ERROR ... Error while setting up pod_point platform for binary_sensor: 'NoneType' object has no attribute 'is_active'
ERROR ... Error while setting up pod_point platform for switch:        'NoneType' object has no attribute 'is_active'
ERROR ... Error while setting up pod_point platform for update:        'NoneType' object has no attribute 'is_active'
```

I've defaulted the status in the coordinator, immediately before the pod list becomes `coordinator.data`. That covers every consumer from one place, which matters because `entity.py` reads it in two: `__update_attrs` via `pod.dict`, and the `charging_allowed` property.

Worth noting `charging_allowed` already anticipated `is_active` being `None` — but not `status` itself being `None`, so it would have raised at line 210 even with the `pod.dict` call fixed.

`ScheduleStatus()` defaults `is_active` to `False`, which also seems the safer reading: an unknown schedule state shouldn't be treated as an active restriction on charging.

This looks like the same root cause as #83.

## 2. Options dialog returns HTTP 500

```
AttributeError: property 'config_entry' of 'PodPointOptionsFlowHandler' object has no setter
  File "/config/custom_components/pod_point/config_flow.py", line 139, in __init__
    self.config_entry = config_entry
```

`OptionsFlow.config_entry` became a read-only property in HA 2024.11, populated by the flow manager. The frontend surfaces the resulting error as *"Config flow could not be loaded: 500 Internal Server Error"* whenever the options dialog is opened. Dropping the assignment is enough — `self.options` is built from the argument directly, and `self.config_entry` still resolves via the base class. 

This could be the fix to #89.

## Testing

Verified on a live HA 2026.8.0 instance against a real Pod Point account. Before the change all four platforms failed at setup; after it, all 17 entities are present and reporting (`sensor.psl_192302_status = available`, lifetime 10,513 kWh, both switches functional), and the options dialog opens instead of 500ing.

Added a regression test to `tests/test_coordinator.py` covering the null-status case and both call sites that used to raise. I wasn't able to run the suite locally — `pytest-homeassistant-custom-component` doesn't install on my Windows/Python 3.14 setup — so I've leaned on CI for that rather than claiming a green run.

`black` is clean on all changed lines. It does want to reformat one pre-existing line in `coordinator.py` (`(new_pods, new_pods_by_id) = ...` at line 73), presumably a newer black than the one last run here; I've left it alone rather than mix unrelated reformatting into the diff.
